### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ to your usage.
 
    ```gradle   
    dependencies {
-     compile 'com.vincentbrison.openlibraries.android:foldablelayout:0.0.1@aar'
+     implementation 'com.vincentbrison.openlibraries.android:foldablelayout:0.0.1@aar'
    }
    ```   
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.